### PR TITLE
Install www.getdbt.com using ssh url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "www.getdbt.com"]
 	path = www.getdbt.com
-	url = https://github.com/fishtown-analytics/www.getdbt.com
+	url = git@github.com:fishtown-analytics/www.getdbt.com.git
 	branch = cloud
 [submodule "reveal.js"]
 	path = reveal.js


### PR DESCRIPTION
I had to do a fresh clone of this repo recently, and because we were using the `https` URL, I couldn't clone the styles.

I think previously we were able to clone URLs using `https` URLs, so when I initially ran `git submodule update` months ago, it worked. 

It's kind of unclear why this hasn't failed yet in prod though... 😅 . My guess is that Netlify is using a cache of the `www.getdbt.com` styles that it successfully cloned months and months ago