### PR TITLE
Make learn slides font smaller

### DIFF
--- a/_config/_includes/options/styles-learn.html
+++ b/_config/_includes/options/styles-learn.html
@@ -60,7 +60,7 @@ h1, h2, h3 {
   }
 
   .remark-slide-content {
-    font-size: 28px;
+    font-size: 24px;
   }
 
   .remark-slide-number:before {


### PR DESCRIPTION
The changes made on #174 to update the font on the learn slides from Lato to Source Sans Pro made the font bigger, thus making the font overflow on some of the slides.