### PR TITLE
Add webrick to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gem "jekyll"
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
Webrick isn't needed per se, but Jekyll expects it and needs it to run locally