### PR TITLE
Update testing.html

### DIFF
--- a/_lessons/testing.html
+++ b/_lessons/testing.html
@@ -222,7 +222,7 @@ select
     payments.payment_id
 from orders
 left join payments
-    on orders.order_id = payments.payment_id
+    on orders.order_id = payments.order_id
 ```
 ```yml
 models:
@@ -236,7 +236,7 @@ models:
 ???
 Examples:
 * Bad deduping
-* Bad joins
+* 1:many relationship between orders and payments unexpectedly causes fan out
 
 ---
 # Q: Why might a test fail?


### PR DESCRIPTION
When reviewing with @alexiswo we determined the example query run against the dataset would not actually error when testing `order_id` for uniqueness. If you join on `order_id`, the resulting model will fail when testing `order_id` for uniqueness.